### PR TITLE
*ignore FIX WIP

### DIFF
--- a/index.js
+++ b/index.js
@@ -213,6 +213,16 @@ module.exports = function (dir, optionalId, optionalName, cfg, extEvents) {
                 fs.mkdirSync(dir);
             }
 
+            // CB-12397 add .gitignore for plugins & platforms to app template
+            // get stock .npmignore; used if template does not contain .gitignore
+            // NOTE: This is part of a workaround for the npm .gitignore/.npmignore
+            // behavior discussed in:
+            // https://github.com/npm/npm/issues/1862
+            // https://github.com/npm/npm/issues/3763
+            // https://github.com/npm/npm/issues/7252
+            // paths.npmignore = path.join(require('cordova-app-hello-world').dirname, '.npmignore');
+            const npmignore = path.join(require('cordova-app-hello-world').dirname, '.npmignore');
+
             try {
                 // Copy files from template to project
                 if (cfg.lib.www.template) {
@@ -263,6 +273,17 @@ module.exports = function (dir, optionalId, optionalName, cfg, extEvents) {
 
                 pkgjson.version = DEFAULT_VERSION;
                 fs.writeFileSync(pkgjsonPath, JSON.stringify(pkgjson, null, 4), 'utf8');
+
+                // CB-12397 add .gitignore for plugins & platforms to app template
+                // get stock .npmignore; used if template does not contain .gitignore
+                // NOTE: This is part of a workaround for the npm .gitignore/.npmignore
+                // behavior discussed in:
+                // https://github.com/npm/npm/issues/1862
+                // https://github.com/npm/npm/issues/3763
+                // https://github.com/npm/npm/issues/7252
+                // XXX TODO USE fs-extra function instead
+                // XXX WAITING FOR apache/cordova-create#14 to be merged
+                shell.cp(npmignore, path.join(dir, '.gitignore'));
             }
 
             // Create basic project structure.

--- a/spec/create.spec.js
+++ b/spec/create.spec.js
@@ -57,80 +57,105 @@ describe('cordova create checks for valid-identifier', function () {
 
 describe('create end-to-end', function () {
 
-    function checkProject () {
+    function checkProjectCommonArtifacts () {
         // Check if top level dirs exist.
         var dirs = ['hooks', 'platforms', 'plugins', 'www'];
         dirs.forEach(function (d) {
             expect(path.join(project, d)).toExist();
         });
-
         expect(path.join(project, 'hooks', 'README.md')).toExist();
 
         // Check if www files exist.
         expect(path.join(project, 'www', 'index.html')).toExist();
+
+        // Check if config.xml exists.
+        expect(path.join(project, 'config.xml')).toExist();
+
+        // Check that .npmignore does not exist
+        expect(path.join(project, 'www', '.npmignore')).not.toExist();
+
+        // index.js and template subdir folder should not exist in top level
+        // (inner files should be copied to the project top level folder)
+        expect(path.join(project, 'index.js')).not.toExist();
+        expect(path.join(project, 'template')).not.toExist();
+
+        // Check that .gitignore does not exist inside of www
+        expect(path.join(project, 'www', '.gitignore')).not.toExist();
+
+        // Check that .npmignore does not exist inside of www
+        expect(path.join(project, 'www', '.npmignore')).not.toExist();
+
+        // Check that config.xml does not exist inside of www
+        expect(path.join(project, 'www', 'config.xml')).not.toExist();
+
+        // Check that no package.json exists inside of www
+        expect(path.join(project, 'www', 'package.json')).not.toExist();
 
         // Check that config.xml was updated.
         var configXml = new ConfigParser(path.join(project, 'config.xml'));
         expect(configXml.packageName()).toEqual(appId);
-
-        // TODO (kamrik): check somehow that we got the right config.xml from the fixture and not some place else.
-        // expect(configXml.name()).toEqual('TestBase');
+        expect(configXml.version()).toEqual('1.0.0');
+        // Check that we got the right config.xml from the fixture and not some place else.
+        expect(configXml.name()).toEqual('TestBase');
     }
 
-    function checkConfigXml () {
-        // Check if top level dirs exist.
-        var dirs = ['hooks', 'platforms', 'plugins', 'www'];
-        dirs.forEach(function (d) {
-            expect(path.join(project, d)).toExist();
-        });
-        expect(path.join(project, 'hooks', 'README.md')).toExist();
+    function checkProjectArtifactsWithConfigFromTemplate () {
+        checkProjectCommonArtifacts();
 
-        // index.js and template subdir folder should not exist (inner files should be copied to the project folder)
-        expect(path.join(project, 'index.js')).not.toExist();
-        expect(path.join(project, 'template')).not.toExist();
-
-        // Check if www files exist.
-        expect(path.join(project, 'www', 'index.html')).toExist();
-        var configXml = new ConfigParser(path.join(project, 'config.xml'));
-        expect(configXml.packageName()).toEqual(appId);
-        expect(configXml.version()).toEqual('1.0.0');
-
-        // Check that config.xml does not exist inside of www
-        expect(path.join(project, 'www', 'config.xml')).not.toExist();
+        // [CB-12397] Check that .gitignore does not exist
+        expect(path.join(project, '.gitignore')).not.toExist();
 
         // Check that we got no package.json
         expect(path.join(project, 'package.json')).not.toExist();
 
         // Check that we got the right config.xml from the template and not stock
+        const configXml = new ConfigParser(path.join(project, 'config.xml'));
         expect(configXml.description()).toEqual('this is the correct config.xml');
     }
 
-    function checkSubDir () {
-        // Check if top level dirs exist.
-        var dirs = ['hooks', 'platforms', 'plugins', 'www'];
-        dirs.forEach(function (d) {
-            expect(path.join(project, d)).toExist();
-        });
-        expect(path.join(project, 'hooks', 'README.md')).toExist();
+    function checkProjectArtifactsWithNoPackageFromTemplate () {
+        checkProjectCommonArtifacts();
 
-        // index.js and template subdir folder should not exist (inner files should be copied to the project folder)
-        expect(path.join(project, 'index.js')).not.toExist();
-        expect(path.join(project, 'template')).not.toExist();
+        // [CB-12397] Check that .gitignore does not exist
+        expect(path.join(project, '.gitignore')).not.toExist();
+
+        // Check that we got no package.json
+        expect(path.join(project, 'package.json')).not.toExist();
+    }
+
+    function checkProjectArtifactsWithPackageFromTemplate () {
+        checkProjectCommonArtifacts();
+
+        // Check if package.json exists.
+        expect(path.join(project, 'package.json')).toExist();
+
+        // [CB-12397] Check that .gitignore does not exist
+        expect(path.join(project, '.gitignore')).not.toExist();
+
+        // Check that we got package.json (the correct one)
+        var pkjson = requireFresh(path.join(project, 'package.json'));
+        // Pkjson.displayName should equal config's name.
+        expect(pkjson.displayName).toEqual('TestBase');
+    }
+
+    function checkProjectArtifactsWithPackageFromSubDir () {
+        checkProjectCommonArtifacts();
+
+        // [CB-12397] Check that .gitignore does not exist
+        expect(path.join(project, '.gitignore')).not.toExist();
 
         // Check if config files exist.
         expect(path.join(project, 'www', 'index.html')).toExist();
 
-        // Check that config.xml was updated.
-        var configXml = new ConfigParser(path.join(project, 'config.xml'));
-        expect(configXml.packageName()).toEqual(appId);
-        expect(configXml.version()).toEqual('1.0.0');
         // Check that we got package.json (the correct one)
         var pkjson = requireFresh(path.join(project, 'package.json'));
+
         // Pkjson.displayName should equal config's name.
         expect(pkjson.displayName).toEqual(appName);
         expect(pkjson.valid).toEqual('true');
 
         // Check that we got the right config.xml
+        const configXml = new ConfigParser(path.join(project, 'config.xml'));
         expect(configXml.description()).toEqual('this is the correct config.xml');
     }
 
@@ -138,7 +163,7 @@ describe('create end-to-end', function () {
         // Create a real project with no template
         // use default cordova-app-hello-world app
         return create(project, appId, appName, {}, events)
-            .then(checkProject)
+            .then(checkProjectArtifactsWithPackageFromTemplate)
             .then(function () {
                 var pkgJson = requireFresh(path.join(project, 'package.json'));
                 // confirm default hello world app copies over package.json and it matched appId
@@ -161,7 +186,7 @@ describe('create end-to-end', function () {
                 expect(fetchSpy).toHaveBeenCalledTimes(1);
                 expect(fetchSpy.calls.argsFor(0)[0]).toBe(config.lib.www.url);
             })
-            .then(checkProject);
+            .then(checkProjectArtifactsWithPackageFromTemplate);
     });
 
     it('should successfully run with NPM package', function () {
@@ -179,7 +204,7 @@ describe('create end-to-end', function () {
                 expect(fetchSpy).toHaveBeenCalledTimes(1);
                 expect(fetchSpy.calls.argsFor(0)[0]).toBe(config.lib.www.url);
             })
-            .then(checkProject);
+            .then(checkProjectArtifactsWithPackageFromTemplate);
     });
 
     it('should successfully run with NPM package and explicitly fetch latest if no version is given', function () {
@@ -198,7 +223,7 @@ describe('create end-to-end', function () {
                 expect(fetchSpy).toHaveBeenCalledTimes(1);
                 expect(fetchSpy.calls.argsFor(0)[0]).toBe(config.lib.www.url + '@latest');
             })
-            .then(checkProject);
+            .then(checkProjectArtifactsWithPackageFromTemplate);
     });
 
     it('should successfully run with template not having a package.json at toplevel', function () {
@@ -211,7 +236,7 @@ describe('create end-to-end', function () {
             }
         };
         return create(project, appId, appName, config, events)
-            .then(checkProject)
+            .then(checkProjectArtifactsWithNoPackageFromTemplate)
             .then(function () {
                 // Check that we got the right config.xml
                 var configXml = new ConfigParser(path.join(project, 'config.xml'));
@@ -229,7 +254,7 @@ describe('create end-to-end', function () {
             }
         };
         return create(project, appId, appName, config, events)
-            .then(checkProject);
+            .then(checkProjectArtifactsWithNoPackageFromTemplate);
     });
 
     it('should successfully run with template having package.json, and subdirectory, and no package.json in subdirectory', function () {
@@ -242,7 +267,7 @@ describe('create end-to-end', function () {
             }
         };
         return create(project, appId, appName, config, events)
-            .then(checkProject);
+            .then(checkProjectArtifactsWithNoPackageFromTemplate);
     });
 
     it('should successfully run with template having package.json, and subdirectory, and package.json in subdirectory', function () {
@@ -255,7 +280,7 @@ describe('create end-to-end', function () {
             }
         };
         return create(project, appId, appName, config, events)
-            .then(checkSubDir);
+            .then(checkProjectArtifactsWithPackageFromSubDir);
     });
 
     it('should successfully run config.xml in the www folder and move it outside', function () {
@@ -268,7 +293,7 @@ describe('create end-to-end', function () {
             }
         };
         return create(project, appId, appName, config, events)
-            .then(checkConfigXml);
+            .then(checkProjectArtifactsWithConfigFromTemplate);
     });
 
     it('should successfully run with www folder as the template', function () {
@@ -281,13 +306,13 @@ describe('create end-to-end', function () {
             }
         };
         return create(project, appId, appName, config, events)
-            .then(checkConfigXml);
+            .then(checkProjectArtifactsWithConfigFromTemplate);
     });
 
     it('should successfully run with existing, empty destination', function () {
         shell.mkdir('-p', project);
         return create(project, appId, appName, {}, events)
-            .then(checkProject);
+            .then(checkProjectArtifactsWithPackageFromTemplate);
     });
 
     describe('when --link-to is provided', function () {
@@ -315,6 +340,7 @@ describe('create end-to-end', function () {
 
                 // Check www/config exists
                 expect(path.join(project, 'www', 'config.xml')).toExist();
+
                 // Check www/config.xml was not updated.
                 var configXml = new ConfigParser(path.join(project, 'www', 'config.xml'));
                 expect(configXml.packageName()).toEqual('io.cordova.hellocordova');
@@ -323,6 +349,7 @@ describe('create end-to-end', function () {
 
                 // Check that config.xml was copied to project/config.xml
                 expect(path.join(project, 'config.xml')).toExist();
+
                 configXml = new ConfigParser(path.join(project, 'config.xml'));
                 expect(configXml.description()).toEqual('this is the correct config.xml');
                 // Check project/config.xml was updated.

--- a/spec/create.spec.js
+++ b/spec/create.spec.js
@@ -129,8 +129,8 @@ describe('create end-to-end', function () {
         // Check if package.json exists.
         expect(path.join(project, 'package.json')).toExist();
 
-        // [CB-12397] Check that .gitignore does not exist
-        expect(path.join(project, '.gitignore')).not.toExist();
+        // [CB-12397] Check that .gitignore exists
+        expect(path.join(project, '.gitignore')).toExist();
 
         // Check that we got package.json (the correct one)
         var pkjson = requireFresh(path.join(project, 'package.json'));
@@ -141,8 +141,8 @@ describe('create end-to-end', function () {
     function checkProjectArtifactsWithPackageFromSubDir () {
         checkProjectCommonArtifacts();
 
-        // [CB-12397] Check that .gitignore does not exist
-        expect(path.join(project, '.gitignore')).not.toExist();
+        // [CB-12397] Check that .gitignore exists
+        expect(path.join(project, '.gitignore')).toExist();
 
         // Check if config files exist.
         expect(path.join(project, 'www', 'index.html')).toExist();


### PR DESCRIPTION
I just reworked my changes in apache/cordova-create#8 to work on master, with better test refactoring, as you requested in <https://github.com/apache/cordova-discuss/issues/69#issuecomment-392765587>. Changes are in 2 commits and I would recommend we keep it that way:
- spec (test) updates needed
- actual change

It still copies from .npmignore to .gitignore if possible, which I think should be really easy to adapt to the needs discussed in apache/cordova-discuss#69.

This change should be considered WIP, with XXX TODO marked to use fs-extra instead of shelljs once apache/cordova-create#14 is merged. Please feel free to use it for your work on apache/cordova-discuss#69 if you like.

Just finished a long day working on this:)